### PR TITLE
Fix subprocess running

### DIFF
--- a/yacpm.cmake
+++ b/yacpm.cmake
@@ -37,7 +37,6 @@ foreach(TRY_PYTHON_EXEC ${PYTHON_EXECUTABLES})
     endif()
 endforeach()
 
-message(${PYTHON_EXECUTABLE})
 if(NOT DEFINED PYTHON_EXECUTABLE)
     message(FATAL_ERROR "Python was not found!")
 endif()

--- a/yacpm.py
+++ b/yacpm.py
@@ -45,7 +45,7 @@ def error(msg: str, print_wrapper: bool = True):
 def info(msg: str, print_wrapper: bool = True):
     text = f"==== {msg}" if print_wrapper else msg
     # normal printing doesn't update realtime with cmake
-    os.system(f"{sys.executable} -c 'print(\"\"\"{text}\"\"\")'")
+    subprocess.run(f'"{sys.executable}" -c "print(\'\'\'{text}\'\'\')"')
 
 def open_read_write(filename: str, parse_json: bool = False) -> Tuple[TextIOWrapper, Any]:
     file = open(filename, "r+")


### PR DESCRIPTION
Running the subprocess for printing should work fine, even with paths containing spaces.